### PR TITLE
Rename module from temporal-opentelemetry to temporal-golang-opentelemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SigNoz/temporal-opentelemetry-instrumentation
+module github.com/SigNoz/temporal-golang-opentelemetry
 
 go 1.24.1
 

--- a/helloworld/connection.go
+++ b/helloworld/connection.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"os"
 
-	"github.com/SigNoz/temporal-opentelemetry-instrumentation/instrument"
+	"github.com/SigNoz/temporal-golang-opentelemetry/instrument"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/interceptor"
 )

--- a/starter/main.go
+++ b/starter/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
 
-	"github.com/SigNoz/temporal-opentelemetry-instrumentation/helloworld"
-	"github.com/SigNoz/temporal-opentelemetry-instrumentation/instrument"
+	"github.com/SigNoz/temporal-golang-opentelemetry/helloworld"
+	"github.com/SigNoz/temporal-golang-opentelemetry/instrument"
 	"github.com/rs/zerolog/log"
 )
 

--- a/worker/main.go
+++ b/worker/main.go
@@ -5,8 +5,8 @@ import (
 
 	"go.temporal.io/sdk/worker"
 
-	"github.com/SigNoz/temporal-opentelemetry-instrumentation/helloworld"
-	"github.com/SigNoz/temporal-opentelemetry-instrumentation/instrument"
+	"github.com/SigNoz/temporal-golang-opentelemetry/helloworld"
+	"github.com/SigNoz/temporal-golang-opentelemetry/instrument"
 )
 
 func main() {


### PR DESCRIPTION
I got linked to this repository from https://signoz.io/docs/integrations/temporal-golang-opentelemetry and it fits my use case perfectly! However, I have issues when trying to import it

```
> go get github.com/SigNoz/temporal-golang-opentelemetry

go: downloading github.com/SigNoz/temporal-golang-opentelemetry v0.0.0-20250618193542-75e016201179
go: github.com/SigNoz/temporal-golang-opentelemetry@upgrade (v0.0.0-20250618193542-75e016201179) requires github.com/SigNoz/temporal-golang-opentelemetry@v0.0.0-20250618193542-75e016201179: parsing go.mod:
	module declares its path as: github.com/SigNoz/temporal-opentelemetry-instrumentation
	        but was required as: github.com/SigNoz/temporal-golang-opentelemetry
```

This PR fixes the Go module path in `go.mod` to match the actual GitHub repository URL, and updates all internal import paths accordingly. Without this fix, external consumers cannot go get this package because Go requires the module path to match the repository URL.